### PR TITLE
Add Terraform OPA policy checks

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -25,4 +25,20 @@ jobs:
       - name: Terraform validate
         run: terraform validate
       - name: Terraform plan
-        run: terraform plan -input=false -lock=false
+        run: terraform plan -input=false -lock=false -out=tfplan
+      - name: Terraform show
+        run: terraform show -json tfplan > plan.json
+      - name: Install OPA and Conftest
+        run: |
+          curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64
+          chmod +x opa && sudo mv opa /usr/local/bin/opa
+          curl -L https://github.com/open-policy-agent/conftest/releases/latest/download/conftest_Linux_x86_64.tar.gz | tar zx -C /usr/local/bin
+      - name: OPA unit tests
+        run: opa test ../../../../../security/opa
+      - name: Conftest policy check
+        run: conftest test plan.json --policy ../../../../../security/opa
+      - name: Upload plan.json
+        uses: actions/upload-artifact@v3
+        with:
+          name: tfplan
+          path: infra/terraform/live/dev/s3/plan.json

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@ dev:
 	bash scripts/dev_bootstrap.sh
 
 test:
-	pre-commit run --all-files
-	pytest
+        pre-commit run --all-files
+        pytest
+        opa test security/opa
 
 fmt:
 	pre-commit run --all-files

--- a/security/opa/s3.rego
+++ b/security/opa/s3.rego
@@ -1,6 +1,6 @@
 package scalenyx.s3
 
-deny[msg] {
+deny contains msg if {
   input.resource.aws_s3_bucket.public
-  msg = "Public S3 buckets are not allowed"
+  msg := "Public S3 buckets are not allowed"
 }

--- a/security/opa/s3_test.rego
+++ b/security/opa/s3_test.rego
@@ -1,0 +1,11 @@
+package scalenyx.s3
+
+test_public_bucket_denied if {
+    msg := deny[_] with input as {"resource": {"aws_s3_bucket": {"public": true}}}
+    msg == "Public S3 buckets are not allowed"
+}
+
+test_private_bucket_allowed if {
+    deny_empty := deny with input as {"resource": {"aws_s3_bucket": {"public": false}}}
+    count(deny_empty) == 0
+}


### PR DESCRIPTION
## Summary
- check Terraform plans against OPA Rego policies via Conftest in CI
- add unit tests for Rego policies and run them in CI
- extend `make test` to include `opa test`

## Testing
- `pre-commit run --files security/opa/s3.rego security/opa/s3_test.rego .github/workflows/ci-terraform.yml Makefile`
- `pytest`
- `./opa test security/opa`

------
https://chatgpt.com/codex/tasks/task_e_68a92d97acc8833288e4a1aa40c831fe