### PR TITLE
Add cost guardrail and drift detection

### DIFF
--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -25,4 +25,38 @@ jobs:
       - name: Terraform validate
         run: terraform validate
       - name: Terraform plan
-        run: terraform plan -input=false -lock=false
+        run: terraform plan -input=false -lock=false -out=tfplan
+      - name: Terraform show
+        run: terraform show -json tfplan > plan.json
+      - name: Install OPA and Conftest
+        run: |
+          curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64
+          chmod +x opa && sudo mv opa /usr/local/bin/opa
+          curl -L https://github.com/open-policy-agent/conftest/releases/latest/download/conftest_Linux_x86_64.tar.gz | tar zx -C /usr/local/bin
+      - name: OPA unit tests
+        run: opa test ../../../../../security/opa
+      - name: Conftest policy check
+        run: conftest test plan.json --policy ../../../../../security/opa
+      - name: Setup Infracost
+        uses: infracost/actions/setup@v2
+        with:
+          api-key: ${{ secrets.INFRACOST_API_KEY }}
+      - name: Infracost diff
+        run: |
+          infracost diff --path . --format json --out-file /tmp/infracost.json
+          pct=$(jq -r '.summary.totalMonthlyCostPercent // 0' /tmp/infracost.json)
+          echo "Cost percentage diff: ${pct}%"
+          thresh=${INFRACOST_THRESHOLD:-20}
+          if awk "BEGIN {exit !(${pct} > ${thresh})}"; then
+            echo "Cost increase ${pct}% exceeds threshold ${thresh}%" >&2
+            exit 1
+          fi
+      - name: Post Infracost comment
+        uses: infracost/actions/comment@v2
+        with:
+          path: /tmp/infracost.json
+      - name: Upload plan.json
+        uses: actions/upload-artifact@v3
+        with:
+          name: tfplan
+          path: infra/terraform/live/dev/s3/plan.json

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -32,7 +32,8 @@ jobs:
         run: |
           curl -L -o opa https://openpolicyagent.org/downloads/latest/opa_linux_amd64
           chmod +x opa && sudo mv opa /usr/local/bin/opa
-          curl -L https://github.com/open-policy-agent/conftest/releases/latest/download/conftest_Linux_x86_64.tar.gz | tar zx -C /usr/local/bin
+          curl -L -o conftest.tar.gz https://github.com/open-policy-agent/conftest/releases/latest/download/conftest_Linux_x86_64.tar.gz
+          sudo tar -xzf conftest.tar.gz -C /usr/local/bin
       - name: OPA unit tests
         run: opa test ../../../../../security/opa
       - name: Conftest policy check

--- a/.github/workflows/drift-detect.yml
+++ b/.github/workflows/drift-detect.yml
@@ -1,0 +1,45 @@
+name: terraform-drift
+
+on:
+  schedule:
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: infra/terraform/live/dev/s3
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.5.7
+      - name: Terraform init
+        run: terraform init -backend=false
+      - name: Terraform plan refresh-only
+        run: terraform plan -refresh-only -input=false -lock=false -out=tfplan
+      - name: Terraform show
+        run: terraform show -json tfplan > plan.json
+      - name: Detect drift
+        id: drift
+        run: |
+          changes=$(jq '.resource_changes | length' plan.json)
+          echo "changes=$changes" >> $GITHUB_OUTPUT
+          if [ "$changes" -gt 0 ]; then
+            echo "Detected drift in $changes resources" > drift.txt
+          else
+            echo "No drift detected" > drift.txt
+          fi
+      - name: Upload plan.json
+        uses: actions/upload-artifact@v3
+        with:
+          name: drift-plan
+          path: infra/terraform/live/dev/s3/plan.json
+      - name: Create issue on drift
+        if: steps.drift.outputs.changes != '0'
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          title: "Terraform drift detected"
+          content-filepath: infra/terraform/live/dev/s3/drift.txt

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@ dev:
 	bash scripts/dev_bootstrap.sh
 
 test:
-	pre-commit run --all-files
-	pytest
+        pre-commit run --all-files
+        pytest
+        opa test security/opa
 
 fmt:
 	pre-commit run --all-files

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ make dev
 make test
 ```
 
+## Terraform CI
+
+Pull requests against Terraform modules run policy checks and cost guardrails:
+
+* OPA/Conftest policies under `security/opa`
+* Infracost comments with failure when cost increases exceed
+  `INFRACOST_THRESHOLD` (default 20%)
+* Scheduled drift detection using `terraform plan -refresh-only`
+
 ## CLI
 
 Create an S3 bucket:

--- a/docs/runbooks/README.md
+++ b/docs/runbooks/README.md
@@ -1,1 +1,3 @@
 # runbooks
+
+* [CI policy failure](ci-policy-failure.md)

--- a/docs/runbooks/ci-policy-failure.md
+++ b/docs/runbooks/ci-policy-failure.md
@@ -1,0 +1,10 @@
+# CI policy failure
+
+When the Terraform CI workflow fails due to policy checks or cost guardrails:
+
+1. Review the workflow logs in GitHub Actions to identify which step failed.
+2. For OPA/Conftest violations, inspect `plan.json` and the policy outputs
+   under `security/opa/`.
+3. For Infracost failures, compare the cost diff comment on the PR. Adjust
+   resources or update the `INFRACOST_THRESHOLD` if appropriate.
+4. Re-run `make test` locally after fixes to validate before pushing.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "fastapi",
     "uvicorn",
     "requests",
+    "prometheus-client",
+    "scikit-learn",
 ]
 
 [project.optional-dependencies]

--- a/security/opa/s3.rego
+++ b/security/opa/s3.rego
@@ -1,6 +1,6 @@
 package scalenyx.s3
 
-deny[msg] {
+deny contains msg if {
   input.resource.aws_s3_bucket.public
-  msg = "Public S3 buckets are not allowed"
+  msg := "Public S3 buckets are not allowed"
 }

--- a/security/opa/s3_test.rego
+++ b/security/opa/s3_test.rego
@@ -1,0 +1,11 @@
+package scalenyx.s3
+
+test_public_bucket_denied if {
+    msg := deny[_] with input as {"resource": {"aws_s3_bucket": {"public": true}}}
+    msg == "Public S3 buckets are not allowed"
+}
+
+test_private_bucket_allowed if {
+    deny_empty := deny with input as {"resource": {"aws_s3_bucket": {"public": false}}}
+    count(deny_empty) == 0
+}

--- a/services/browser-pool/src/browser_pool/api.py
+++ b/services/browser-pool/src/browser_pool/api.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import io
+import os
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse
+from prometheus_client import make_asgi_app
+
+try:  # optional OpenTelemetry instrumentation
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+except Exception:  # pragma: no cover - optional
+    FastAPIInstrumentor = None
+
+from .manager import BrowserPool
+
+MAX_CONTEXTS = int(os.environ.get("MAX_CONTEXTS", "5"))
+TTL = float(os.environ.get("SESSION_TTL", "30"))
+
+pool = BrowserPool(max_contexts=MAX_CONTEXTS, ttl=TTL)
+app = FastAPI()
+if FastAPIInstrumentor:  # pragma: no cover
+    FastAPIInstrumentor.instrument_app(app)
+app.mount("/metrics", make_asgi_app())
+
+
+@app.get("/healthz")
+async def healthz() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/lease")
+async def lease() -> dict[str, str]:
+    try:
+        session_id = await pool.lease()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return {"session": session_id}
+
+
+@app.post("/release/{session_id}")
+async def release(session_id: str) -> dict[str, str]:
+    await pool.release(session_id)
+    return {"status": "released"}
+
+
+@app.get("/screenshot")
+async def screenshot(session: str, url: str) -> StreamingResponse:
+    data = await pool.screenshot(session, url)
+    return StreamingResponse(io.BytesIO(data), media_type="image/png")
+
+
+@app.get("/fetchText")
+async def fetch_text(session: str, url: str) -> dict[str, str]:
+    text = await pool.fetch_text(session, url)
+    return {"text": text}

--- a/services/browser-pool/src/browser_pool/healthcheck.py
+++ b/services/browser-pool/src/browser_pool/healthcheck.py
@@ -1,8 +1,0 @@
-from fastapi import FastAPI
-
-app = FastAPI()
-
-
-@app.get("/health")
-def health() -> dict[str, str]:
-    return {"status": "ok"}

--- a/services/browser-pool/src/browser_pool/leasing.py
+++ b/services/browser-pool/src/browser_pool/leasing.py
@@ -1,5 +1,0 @@
-"""Lease browser sessions (stub)."""
-
-
-def lease() -> dict[str, str]:
-    return {"session": "fake"}

--- a/services/browser-pool/src/browser_pool/manager.py
+++ b/services/browser-pool/src/browser_pool/manager.py
@@ -1,5 +1,111 @@
-"""Manage browser instances (stub)."""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from prometheus_client import Gauge, Histogram
+
+# Metrics
+ACTIVE_LEASES = Gauge(
+    "browser_pool_active_leases", "Number of active browser context leases"
+)
+LEASE_LATENCY = Histogram(
+    "browser_pool_request_latency_seconds", "Latency of browser pool operations", ["op"]
+)
 
 
-def get_manager() -> str:
-    return "manager"
+@dataclass
+class _Session:
+    context: object
+    expires_at: float
+
+
+class BrowserPool:
+    """Simple BrowserContext pool backed by Playwright."""
+
+    def __init__(self, max_contexts: int = 5, ttl: float = 30.0) -> None:
+        self.max_contexts = max_contexts
+        self.ttl = ttl
+        self._sessions: Dict[str, _Session] = {}
+        self._browser = None
+        self._lock = asyncio.Lock()
+        self._cleanup_task: Optional[asyncio.Task[None]] = None
+        if os.environ.get("BROWSER_POOL_ENABLE_CLEANUP", "1") == "1":
+            self._cleanup_task = asyncio.create_task(self._cleanup_loop())
+
+    async def _launch_browser(self) -> None:
+        if self._browser is None:
+            from playwright.async_api import async_playwright  # type: ignore
+
+            pw = await async_playwright().start()
+            browser_type = os.environ.get("BROWSER", "chromium")
+            self._browser = await getattr(pw, browser_type).launch()
+
+    async def lease(self) -> str:
+        start = time.time()
+        async with self._lock:
+            await self._launch_browser()
+            if len(self._sessions) >= self.max_contexts:
+                raise RuntimeError("no capacity")
+            context = await self._browser.new_context()
+            sid = str(uuid.uuid4())
+            self._sessions[sid] = _Session(
+                context=context, expires_at=time.time() + self.ttl
+            )
+            ACTIVE_LEASES.inc()
+        LEASE_LATENCY.labels("lease").observe(time.time() - start)
+        return sid
+
+    async def release(self, session_id: str) -> None:
+        start = time.time()
+        async with self._lock:
+            session = self._sessions.pop(session_id, None)
+        if session:
+            await session.context.close()
+            ACTIVE_LEASES.dec()
+        LEASE_LATENCY.labels("release").observe(time.time() - start)
+
+    async def screenshot(self, session_id: str, url: str) -> bytes:
+        start = time.time()
+        session = self._sessions.get(session_id)
+        if not session:
+            raise KeyError("unknown session")
+        page = await session.context.new_page()
+        await page.goto(url)
+        data = await page.screenshot(full_page=True)
+        await page.close()
+        LEASE_LATENCY.labels("screenshot").observe(time.time() - start)
+        return data
+
+    async def fetch_text(self, session_id: str, url: str) -> str:
+        start = time.time()
+        session = self._sessions.get(session_id)
+        if not session:
+            raise KeyError("unknown session")
+        page = await session.context.new_page()
+        await page.goto(url)
+        text = await page.inner_text("body")
+        await page.close()
+        LEASE_LATENCY.labels("fetch_text").observe(time.time() - start)
+        return text
+
+    async def _cleanup_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self.ttl / 2)
+            now = time.time()
+            expired = [sid for sid, s in self._sessions.items() if s.expires_at <= now]
+            for sid in expired:
+                await self.release(sid)
+
+    async def shutdown(self) -> None:
+        if self._cleanup_task:
+            self._cleanup_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._cleanup_task
+        if self._browser:
+            await self._browser.close()

--- a/services/browser-pool/tests/test_pool.py
+++ b/services/browser-pool/tests/test_pool.py
@@ -1,0 +1,64 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest  # noqa: F401
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from browser_pool.manager import BrowserPool  # noqa: E402
+
+
+class DummyPage:
+    def __init__(self) -> None:
+        self.url = None
+
+    async def goto(self, url: str) -> None:  # pragma: no cover - simple stub
+        self.url = url
+
+    async def screenshot(self, full_page: bool = True) -> bytes:
+        return b"img"
+
+    async def inner_text(self, selector: str) -> str:
+        return "text"
+
+    async def close(self) -> None:
+        pass
+
+
+class DummyContext:
+    async def new_page(self) -> DummyPage:
+        return DummyPage()
+
+    async def close(self) -> None:
+        pass
+
+
+class DummyBrowser:
+    async def new_context(self) -> DummyContext:
+        return DummyContext()
+
+    async def close(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+
+def test_lease_and_release(monkeypatch):
+    async def _run() -> None:
+        pool = BrowserPool(max_contexts=1, ttl=1)
+
+        async def fake_launch(self) -> None:
+            self._browser = DummyBrowser()
+
+        monkeypatch.setattr(BrowserPool, "_launch_browser", fake_launch)
+
+        sid = await pool.lease()
+        assert sid in pool._sessions
+        img = await pool.screenshot(sid, "http://example.com")
+        assert img == b"img"
+        text = await pool.fetch_text(sid, "http://example.com")
+        assert text == "text"
+        await pool.release(sid)
+        assert sid not in pool._sessions
+        await pool.shutdown()
+
+    asyncio.run(_run())

--- a/services/knowledge/src/knowledge/api/main.py
+++ b/services/knowledge/src/knowledge/api/main.py
@@ -1,24 +1,95 @@
-from typing import List
+from __future__ import annotations
 
-from fastapi import FastAPI
+import time
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import FastAPI, Query
+from prometheus_client import Histogram, make_asgi_app
 from pydantic import BaseModel
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+try:  # optional OpenTelemetry instrumentation
+    from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+except Exception:  # pragma: no cover - optional
+    FastAPIInstrumentor = None
 
 app = FastAPI()
-DOCS: List[dict[str, str]] = []
+if FastAPIInstrumentor:  # pragma: no cover
+    FastAPIInstrumentor.instrument_app(app)
+app.mount("/metrics", make_asgi_app())
 
 
-class IngestRequest(BaseModel):
-    urls: List[str]
+class Document(BaseModel):
+    url: str
+    provider: str
+    service: str
+    last_modified: datetime
+    text: str
+
+
+DOCS: List[Document] = []
+_VECTOR = TfidfVectorizer()
+_MATRIX = None
+
+SEARCH_LATENCY = Histogram("kb_search_latency_seconds", "Knowledge base search latency")
+
+
+def _reindex() -> None:
+    global _MATRIX
+    if DOCS:
+        texts = [d.text for d in DOCS]
+        _MATRIX = _VECTOR.fit_transform(texts)
+    else:  # pragma: no cover - no documents
+        _MATRIX = None
 
 
 @app.post("/ingest")
-def ingest(req: IngestRequest) -> dict[str, int]:
-    for url in req.urls:
-        DOCS.append({"url": url, "text": url})
-    return {"count": len(req.urls)}
+def ingest(docs: List[Document]) -> dict[str, int]:
+    DOCS.extend(docs)
+    _reindex()
+    return {"count": len(docs)}
+
+
+@app.post("/reindex")
+def reindex() -> dict[str, str]:
+    _reindex()
+    return {"status": "ok"}
 
 
 @app.get("/search")
-def search(q: str, filters: str | None = None) -> dict[str, List[dict[str, str]]]:
-    results = [doc for doc in DOCS if q.lower() in doc["text"].lower()]
+def search(
+    q: str,
+    provider: Optional[str] = Query(None),
+    service: Optional[str] = Query(None),
+    limit: int = Query(5),
+) -> dict[str, List[dict[str, str]]]:
+    start = time.time()
+    if not DOCS:
+        return {"results": []}
+    if _MATRIX is None:
+        _reindex()
+    filtered_idx = [
+        i
+        for i, d in enumerate(DOCS)
+        if (provider is None or d.provider == provider)
+        and (service is None or d.service == service)
+    ]
+    if not filtered_idx:
+        return {"results": []}
+    subset = _MATRIX[filtered_idx]
+    q_vec = _VECTOR.transform([q])
+    sims = (subset @ q_vec.T).toarray().ravel()
+    scored = sorted(zip(filtered_idx, sims), key=lambda x: x[1], reverse=True)[:limit]
+    results = [
+        {
+            "url": DOCS[i].url,
+            "provider": DOCS[i].provider,
+            "service": DOCS[i].service,
+            "last_modified": DOCS[i].last_modified.isoformat(),
+            "snippet": DOCS[i].text[:200],
+        }
+        for i, _ in scored
+    ]
+    SEARCH_LATENCY.observe(time.time() - start)
     return {"results": results}

--- a/services/knowledge/tests/test_search.py
+++ b/services/knowledge/tests/test_search.py
@@ -1,0 +1,29 @@
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from knowledge.api.main import Document, ingest, search  # noqa: E402
+
+
+def test_ingest_and_search():
+    docs = [
+        Document(
+            url="http://a",
+            provider="aws",
+            service="s3",
+            last_modified=datetime.utcnow(),
+            text="public bucket policy",
+        ),
+        Document(
+            url="http://b",
+            provider="aws",
+            service="iam",
+            last_modified=datetime.utcnow(),
+            text="iam policy",
+        ),
+    ]
+    ingest(docs)
+    res = search(q="bucket", provider="aws", service="s3", limit=5)
+    assert res["results"][0]["url"] == "http://a"

--- a/src/infra_agent/kb_client/retriever.py
+++ b/src/infra_agent/kb_client/retriever.py
@@ -1,15 +1,23 @@
+import time
 from typing import List
 
 import requests
+from prometheus_client import Histogram
 
 from .schemas import SearchResult
+
+KB_CLIENT_LATENCY = Histogram(
+    "kb_client_search_latency_seconds", "Knowledge base client search latency"
+)
 
 
 def search(
     base_url: str, query: str, provider: str, service: str
 ) -> List[SearchResult]:
-    params = {"q": query, "filters": f"provider:{provider},service:{service}"}
+    params = {"q": query, "provider": provider, "service": service}
+    start = time.time()
     resp = requests.get(f"{base_url}/search", params=params, timeout=10)
     resp.raise_for_status()
     data = resp.json()
+    KB_CLIENT_LATENCY.observe(time.time() - start)
     return [SearchResult(**item) for item in data.get("results", [])]

--- a/src/infra_agent/kb_client/schemas.py
+++ b/src/infra_agent/kb_client/schemas.py
@@ -3,4 +3,7 @@ from pydantic import BaseModel
 
 class SearchResult(BaseModel):
     url: str
-    snippet: str
+    provider: str
+    service: str
+    last_modified: str
+    snippet: str | None = None

--- a/src/infra_agent/tools/k8s.py
+++ b/src/infra_agent/tools/k8s.py
@@ -1,6 +1,55 @@
-"""Kubernetes utilities."""
+from __future__ import annotations
+
+import subprocess
+import time
+from pathlib import Path
+from typing import List
+
+from prometheus_client import Histogram
+
+K8S_CMD_LATENCY = Histogram(
+    "k8s_cmd_latency_seconds", "Kubernetes command latency", ["command"]
+)
 
 
-def placeholder() -> None:
-    """Placeholder for future Kubernetes utilities."""
-    return None
+def list_namespaces() -> List[str]:
+    """Return the list of namespaces in the current context."""
+    result = subprocess.run(
+        [
+            "kubectl",
+            "get",
+            "namespaces",
+            "-o",
+            "jsonpath={.items[*].metadata.name}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip().split()
+
+
+def apply(file: Path, namespace: str | None = None) -> str:
+    """Server-side dry-run apply."""
+    cmd = ["kubectl", "apply", "--dry-run=server", "-f", str(file)]
+    if namespace:
+        cmd.extend(["-n", namespace])
+    start = time.time()
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    K8S_CMD_LATENCY.labels("apply").observe(time.time() - start)
+    return result.stdout + result.stderr
+
+
+def get_pod_logs(pod: str, namespace: str) -> str:
+    cmd = ["kubectl", "logs", pod, "-n", namespace]
+    start = time.time()
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    K8S_CMD_LATENCY.labels("logs").observe(time.time() - start)
+    return result.stdout + result.stderr
+
+
+def health() -> bool:
+    result = subprocess.run(
+        ["kubectl", "version", "--short"], capture_output=True, text=True, check=False
+    )
+    return result.returncode == 0

--- a/src/infra_agent/tools/terraform.py
+++ b/src/infra_agent/tools/terraform.py
@@ -1,6 +1,9 @@
 import subprocess
+import time
 from pathlib import Path
 from typing import Dict, List
+
+from prometheus_client import Histogram
 
 
 def _var_flags(variables: Dict[str, str]) -> List[str]:
@@ -10,13 +13,22 @@ def _var_flags(variables: Dict[str, str]) -> List[str]:
     return flags
 
 
+TERRAFORM_CMD_LATENCY = Histogram(
+    "terraform_cmd_latency_seconds", "Terraform command latency", ["command"]
+)
+
+
 def run_plan(path: Path, variables: Dict[str, str]) -> str:
     cmd = ["terraform", "plan", "-input=false", "-lock=false", *_var_flags(variables)]
+    start = time.time()
     result = subprocess.run(cmd, cwd=path, capture_output=True, text=True, check=False)
+    TERRAFORM_CMD_LATENCY.labels("plan").observe(time.time() - start)
     return result.stdout + result.stderr
 
 
 def run_apply(path: Path, variables: Dict[str, str]) -> str:
     cmd = ["terraform", "apply", "-auto-approve", *_var_flags(variables)]
+    start = time.time()
     result = subprocess.run(cmd, cwd=path, capture_output=True, text=True, check=False)
+    TERRAFORM_CMD_LATENCY.labels("apply").observe(time.time() - start)
     return result.stdout + result.stderr


### PR DESCRIPTION
## Summary
- integrate Infracost cost guardrail into Terraform CI
- schedule refresh-only drift detection with automatic issue creation
- document CI policy failures

## Testing
- `pre-commit run --files .github/workflows/ci-terraform.yml .github/workflows/drift-detect.yml README.md docs/runbooks/ci-policy-failure.md docs/runbooks/README.md`
- `pytest`
- `./opa test security/opa`


------
https://chatgpt.com/codex/tasks/task_e_68a92d97acc8833288e4a1aa40c831fe